### PR TITLE
fix: Remove unused `core-js` from `dependencies`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3276,7 +3276,8 @@
     "core-js": {
       "version": "3.6.4",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
+      "dev": true
     },
     "core-js-compat": {
       "version": "3.6.4",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "test": "test"
   },
   "dependencies": {
-    "core-js": "^3.6.4",
     "is-plain-obj": "^2.1.0",
     "read-pkg-up": "^7.0.1"
   },


### PR DESCRIPTION
**Which problem is this pull request solving?**

When I install `get-bin-path`, the unused module `core-js` is also installed.

**List other issues or pull requests related to this problem**

N/A

**Describe the solution you've chosen**

I moved it to `devDependencies`, just in case I was missing the ultimate reason it is even specified in package.json.

**Describe alternatives you've considered**

Removing it entirely, since it is not a direct dependency in any context. It's a transitive dependency of several direct `devDependencies`, however.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be
      seen below.
