### PR TITLE
Document better usage with `execa` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ const { getBinPath } = require('get-bin-path')
 
 test('Binary file should return "true"', async (t) => {
   const binPath = await getBinPath()
-  const { stdout } = await execa(binPath)
+  const { stdout } = await execa.node(binPath)
   t.is(stdout, 'true')
 })
 ```


### PR DESCRIPTION
Hello!

The readme suggests calling `execa(binPath)`, but sadly this can give `EACCES` errors some times - happened to me right now in CI, although it worked on my machine (windows).

I believe this is because executing the `.js` file directly requires it to have `+x` permission in Linux. In windows, I would guess this is just another magic `execa` is doing under the hood and it works by luck.

In short, to avoid the risk of `+x` permission issues, I think using `execa.node` instead of `execa` is better.

It took me a while to figure this out :facepalm: 